### PR TITLE
feat: show link count badge on Tags and Buckets pages (closes #13)

### DIFF
--- a/app/Http/Controllers/Dashboard/BucketController.php
+++ b/app/Http/Controllers/Dashboard/BucketController.php
@@ -18,7 +18,7 @@ class BucketController extends Controller
     public function index(): Response
     {
         return Inertia::render('dashboard/Buckets', [
-            'buckets' => Bucket::orderBy('is_inbox', 'desc')->orderBy('name')->get(),
+            'buckets' => Bucket::withCount('links')->orderBy('is_inbox', 'desc')->orderBy('name')->get(),
         ]);
     }
 

--- a/app/Http/Controllers/Dashboard/TagController.php
+++ b/app/Http/Controllers/Dashboard/TagController.php
@@ -18,7 +18,7 @@ class TagController extends Controller
     public function index(): Response
     {
         return Inertia::render('dashboard/Tags', [
-            'tags' => Tag::orderBy('name')->get(),
+            'tags' => Tag::withCount('links')->orderBy('name')->get(),
         ]);
     }
 

--- a/resources/js/pages/dashboard/Buckets.vue
+++ b/resources/js/pages/dashboard/Buckets.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Form, Head, router } from '@inertiajs/vue3';
-import { Pencil, Trash2 } from 'lucide-vue-next';
+import { Link as LinkIcon, Pencil, Trash2 } from 'lucide-vue-next';
 import { ref } from 'vue';
 import BucketController from '@/actions/App/Http/Controllers/Dashboard/BucketController';
 import { useToast } from '@/composables/useToast';
@@ -19,6 +19,7 @@ type Bucket = {
     name: string;
     color: string;
     is_inbox: boolean;
+    links_count: number;
 };
 
 type Props = {
@@ -193,6 +194,15 @@ function deleteBucket() {
 
                 <template v-else>
                     <span class="flex-1 font-medium">{{ bucket.name }}</span>
+
+                    <span
+                        class="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                        :aria-label="`${bucket.links_count} links`"
+                    >
+                        <LinkIcon class="size-3 shrink-0" />
+                        {{ bucket.links_count }}
+                    </span>
+
                     <span
                         v-if="bucket.is_inbox"
                         class="text-xs text-muted-foreground"

--- a/resources/js/pages/dashboard/Tags.vue
+++ b/resources/js/pages/dashboard/Tags.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Form, Head, router } from '@inertiajs/vue3';
-import { Copy, Pencil, Trash2 } from 'lucide-vue-next';
+import { Copy, Link as LinkIcon, Pencil, Trash2 } from 'lucide-vue-next';
 import { ref } from 'vue';
 import TagController from '@/actions/App/Http/Controllers/Dashboard/TagController';
 import { useToast } from '@/composables/useToast';
@@ -23,6 +23,7 @@ type Tag = {
     description: string | null;
     color: string;
     is_public: boolean;
+    links_count: number;
 };
 
 type Props = {
@@ -258,6 +259,14 @@ async function copyUrl(slug: string) {
                         />
 
                         <span class="flex-1 font-medium">{{ tag.name }}</span>
+
+                        <span
+                            class="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                            :aria-label="`${tag.links_count} links`"
+                        >
+                            <LinkIcon class="size-3 shrink-0" />
+                            {{ tag.links_count }}
+                        </span>
 
                         <code
                             class="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"

--- a/tests/Feature/BucketCrudTest.php
+++ b/tests/Feature/BucketCrudTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Bucket;
+use App\Models\Link;
 use App\Models\User;
 
 beforeEach(function () {
@@ -67,6 +68,16 @@ test('authenticated user can delete a non-inbox bucket', function () {
         ->assertRedirect();
 
     expect($bucket->fresh()->deleted_at)->not->toBeNull();
+});
+
+test('buckets index includes links_count', function () {
+    $bucket = Bucket::factory()->inbox()->create();
+    Link::factory()->count(2)->create(['bucket_id' => $bucket->id]);
+
+    $this->get(route('dashboard.buckets.index'))
+        ->assertInertia(fn ($page) => $page
+            ->where('buckets.0.links_count', 2)
+        );
 });
 
 test('inbox bucket cannot be deleted', function () {

--- a/tests/Feature/TagCrudTest.php
+++ b/tests/Feature/TagCrudTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Bucket;
+use App\Models\Link;
 use App\Models\Tag;
 use App\Models\User;
 
@@ -95,6 +97,19 @@ test('update preserves slug when name unchanged', function () {
     ]);
 
     expect($tag->fresh()->slug)->toBe('frontend');
+});
+
+test('tags index includes links_count', function () {
+    $inbox = Bucket::factory()->inbox()->create();
+    $tag = Tag::factory()->create();
+    Link::factory()->count(3)->create(['bucket_id' => $inbox->id])->each(
+        fn ($link) => $link->tags()->attach($tag),
+    );
+
+    $this->get(route('dashboard.tags.index'))
+        ->assertInertia(fn ($page) => $page
+            ->where('tags.0.links_count', 3)
+        );
 });
 
 test('authenticated user can delete a tag', function () {


### PR DESCRIPTION
Each tag and bucket row now shows a small badge with a chain-link icon and the number of active links assigned to it, including 0 for unused items. Backend uses withCount('links') for a single efficient query.