### PR TITLE
feat: auto-fetch URL metadata on link creation (closes #7)

### DIFF
--- a/app/Http/Controllers/Dashboard/MetaFetchController.php
+++ b/app/Http/Controllers/Dashboard/MetaFetchController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Dashboard;
+
+use App\Http\Controllers\Controller;
+use App\Services\MetaFetchService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MetaFetchController extends Controller
+{
+    public function __construct(private readonly MetaFetchService $metaFetchService) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->validate(['url' => ['required', 'url']]);
+
+        $meta = $this->metaFetchService->fetch($request->string('url')->toString());
+
+        return response()->json($meta);
+    }
+}

--- a/app/Services/MetaFetchService.php
+++ b/app/Services/MetaFetchService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+class MetaFetchService
+{
+    /**
+     * @return array{title: string|null, description: string|null}
+     */
+    public function fetch(string $url): array
+    {
+        try {
+            $response = Http::timeout(5)
+                ->withHeaders(['Accept' => 'text/html'])
+                ->get($url);
+
+            if (! $response->successful()) {
+                return ['title' => null, 'description' => null];
+            }
+
+            return $this->parse($response->body());
+        } catch (ConnectionException) {
+            return ['title' => null, 'description' => null];
+        } catch (\Exception) {
+            return ['title' => null, 'description' => null];
+        }
+    }
+
+    /**
+     * @return array{title: string|null, description: string|null}
+     */
+    private function parse(string $html): array
+    {
+        $doc = new \DOMDocument;
+
+        libxml_use_internal_errors(true);
+        $doc->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        libxml_clear_errors();
+
+        $title = $this->extractTitle($doc);
+        $description = $this->extractDescription($doc);
+
+        return ['title' => $title, 'description' => $description];
+    }
+
+    private function extractTitle(\DOMDocument $doc): ?string
+    {
+        $nodes = $doc->getElementsByTagName('title');
+
+        if ($nodes->length === 0) {
+            return null;
+        }
+
+        $text = trim($nodes->item(0)->textContent);
+
+        return $text !== '' ? $text : null;
+    }
+
+    private function extractDescription(\DOMDocument $doc): ?string
+    {
+        foreach ($doc->getElementsByTagName('meta') as $meta) {
+            $name = strtolower((string) $meta->getAttribute('name'));
+            $property = strtolower((string) $meta->getAttribute('property'));
+
+            if ($name === 'description' || $property === 'og:description') {
+                $content = trim($meta->getAttribute('content'));
+
+                if ($content !== '') {
+                    return $content;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/resources/js/composables/useMetaFetch.ts
+++ b/resources/js/composables/useMetaFetch.ts
@@ -1,0 +1,62 @@
+import { ref } from 'vue';
+import MetaFetchController from '@/actions/App/Http/Controllers/Dashboard/MetaFetchController';
+
+type MetaResult = {
+    title: string | null;
+    description: string | null;
+};
+
+type UseMetaFetch = {
+    fetching: Readonly<ReturnType<typeof ref<boolean>>>;
+    failed: Readonly<ReturnType<typeof ref<boolean>>>;
+    fetch: (url: string) => void;
+};
+
+export function useMetaFetch(onSuccess: (meta: MetaResult) => void): UseMetaFetch {
+    const fetching = ref(false);
+    const failed = ref(false);
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    function fetch(url: string) {
+        if (timer) {
+            clearTimeout(timer);
+        }
+
+        failed.value = false;
+
+        if (!url) {
+            return;
+        }
+
+        timer = setTimeout(async () => {
+            fetching.value = true;
+
+            try {
+                const response = await window.fetch(MetaFetchController.url(), {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '',
+                        Accept: 'application/json',
+                    },
+                    body: JSON.stringify({ url }),
+                });
+
+                if (!response.ok) {
+                    failed.value = true;
+                    return;
+                }
+
+                const meta: MetaResult = await response.json();
+                onSuccess(meta);
+            } catch {
+                failed.value = true;
+            } finally {
+                fetching.value = false;
+            }
+        }, 500);
+    }
+
+    return { fetching, failed, fetch };
+}

--- a/resources/js/pages/dashboard/Links.vue
+++ b/resources/js/pages/dashboard/Links.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { Form, Head, router } from '@inertiajs/vue3';
-import { Pencil, Trash2 } from 'lucide-vue-next';
+import { Loader2, Pencil, Trash2 } from 'lucide-vue-next';
 import { ref } from 'vue';
 import LinkController from '@/actions/App/Http/Controllers/Dashboard/LinkController';
+import { useMetaFetch } from '@/composables/useMetaFetch';
 import { useToast } from '@/composables/useToast';
 import ConfirmModal from '@/components/ConfirmModal.vue';
 import Heading from '@/components/Heading.vue';
@@ -57,8 +58,16 @@ defineOptions({
 
 const { toast } = useToast();
 
+const createUrl = ref('');
+const createTitle = ref('');
+const createDescription = ref('');
 const createBucketId = ref<number>(props.inboxBucketId);
 const createTagIds = ref<number[]>([]);
+
+const { fetching: metaFetching, failed: metaFailed, fetch: fetchMeta } = useMetaFetch((meta) => {
+    if (meta.title && !createTitle.value) createTitle.value = meta.title;
+    if (meta.description && !createDescription.value) createDescription.value = meta.description;
+});
 
 const editingLink = ref<Link | null>(null);
 const editBucketId = ref<number>(0);
@@ -109,6 +118,9 @@ function deleteLink() {
             v-slot="{ errors, processing }"
             @success="
                 () => {
+                    createUrl = '';
+                    createTitle = '';
+                    createDescription = '';
                     createBucketId = props.inboxBucketId;
                     createTagIds = [];
                     toast('Link added', 'success');
@@ -118,13 +130,24 @@ function deleteLink() {
             <div class="grid gap-4 sm:grid-cols-2">
                 <div class="flex flex-col gap-2">
                     <Label for="link-url">URL</Label>
-                    <Input
-                        id="link-url"
-                        name="url"
-                        type="url"
-                        placeholder="https://example.com"
-                        autocomplete="off"
-                    />
+                    <div class="relative">
+                        <Input
+                            id="link-url"
+                            v-model="createUrl"
+                            name="url"
+                            type="url"
+                            placeholder="https://example.com"
+                            autocomplete="off"
+                            @input="fetchMeta(createUrl)"
+                        />
+                        <Loader2
+                            v-if="metaFetching"
+                            class="absolute right-2.5 top-2.5 size-4 animate-spin text-muted-foreground"
+                        />
+                    </div>
+                    <p v-if="metaFailed" class="text-xs text-muted-foreground">
+                        Could not load metadata for this URL.
+                    </p>
                     <InputError :message="errors.url" />
                 </div>
 
@@ -132,6 +155,7 @@ function deleteLink() {
                     <Label for="link-title">Title</Label>
                     <Input
                         id="link-title"
+                        v-model="createTitle"
                         name="title"
                         placeholder="Link title"
                         autocomplete="off"
@@ -143,6 +167,7 @@ function deleteLink() {
                     <Label for="link-description">Description</Label>
                     <Textarea
                         id="link-description"
+                        v-model="createDescription"
                         name="description"
                         placeholder="Optional description"
                         class="resize-none"

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Dashboard\BucketController;
 use App\Http\Controllers\Dashboard\LinkController;
+use App\Http\Controllers\Dashboard\MetaFetchController;
 use App\Http\Controllers\Dashboard\TagController as DashboardTagController;
 use App\Http\Controllers\TagController;
 use Illuminate\Support\Facades\Route;
@@ -25,6 +26,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('dashboard/tags', [DashboardTagController::class, 'store'])->name('dashboard.tags.store');
     Route::patch('dashboard/tags/{tag}', [DashboardTagController::class, 'update'])->name('dashboard.tags.update');
     Route::delete('dashboard/tags/{tag}', [DashboardTagController::class, 'destroy'])->name('dashboard.tags.destroy');
+
+    Route::post('dashboard/links/fetch-meta', MetaFetchController::class)->name('dashboard.links.fetch-meta');
 
     Route::get('dashboard/links', [LinkController::class, 'index'])->name('dashboard.links.index');
     Route::post('dashboard/links', [LinkController::class, 'store'])->name('dashboard.links.store');

--- a/tests/Feature/MetaFetchEndpointTest.php
+++ b/tests/Feature/MetaFetchEndpointTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+    $this->actingAs(User::factory()->create());
+});
+
+test('endpoint returns title and description as json', function () {
+    Http::fake(['*' => Http::response(
+        '<html><head><title>Example</title><meta name="description" content="Desc" /></head></html>',
+    )]);
+
+    $this->postJson(route('dashboard.links.fetch-meta'), ['url' => 'https://example.com'])
+        ->assertOk()
+        ->assertJson(['title' => 'Example', 'description' => 'Desc']);
+});
+
+test('endpoint returns nulls when meta is missing', function () {
+    Http::fake(['*' => Http::response('<html><head></head></html>')]);
+
+    $this->postJson(route('dashboard.links.fetch-meta'), ['url' => 'https://example.com'])
+        ->assertOk()
+        ->assertJson(['title' => null, 'description' => null]);
+});
+
+test('endpoint requires authentication', function () {
+    auth()->logout();
+
+    $this->postJson(route('dashboard.links.fetch-meta'), ['url' => 'https://example.com'])
+        ->assertUnauthorized();
+});
+
+test('endpoint validates url field', function () {
+    $this->postJson(route('dashboard.links.fetch-meta'), ['url' => 'not-a-url'])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['url']);
+});

--- a/tests/Feature/MetaFetchServiceTest.php
+++ b/tests/Feature/MetaFetchServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Services\MetaFetchService;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+test('returns title and description from html', function () {
+    Http::fake(['*' => Http::response(
+        '<html><head><title>Hello World</title><meta name="description" content="A description" /></head></html>',
+    )]);
+
+    $result = app(MetaFetchService::class)->fetch('https://example.com');
+
+    expect($result['title'])->toBe('Hello World');
+    expect($result['description'])->toBe('A description');
+});
+
+test('returns only title when description is missing', function () {
+    Http::fake(['*' => Http::response(
+        '<html><head><title>Only Title</title></head></html>',
+    )]);
+
+    $result = app(MetaFetchService::class)->fetch('https://example.com');
+
+    expect($result['title'])->toBe('Only Title');
+    expect($result['description'])->toBeNull();
+});
+
+test('reads og:description as fallback', function () {
+    Http::fake(['*' => Http::response(
+        '<html><head><title>Page</title><meta property="og:description" content="OG desc" /></head></html>',
+    )]);
+
+    $result = app(MetaFetchService::class)->fetch('https://example.com');
+
+    expect($result['description'])->toBe('OG desc');
+});
+
+test('returns null values on connection failure', function () {
+    Http::fake(['*' => fn () => throw new ConnectionException('timeout')]);
+
+    $result = app(MetaFetchService::class)->fetch('https://unreachable.example.com');
+
+    expect($result['title'])->toBeNull();
+    expect($result['description'])->toBeNull();
+});
+
+test('returns null values on non-successful response', function () {
+    Http::fake(['*' => Http::response('', 404)]);
+
+    $result = app(MetaFetchService::class)->fetch('https://example.com/not-found');
+
+    expect($result['title'])->toBeNull();
+    expect($result['description'])->toBeNull();
+});


### PR DESCRIPTION
POST /dashboard/links/fetch-meta fetches <title> and <meta description> (with og:description fallback) from a given URL server-side (no CORS). A 500ms debounce in useMetaFetch calls the endpoint on URL input and pre-fills title/description only if the fields are still empty. Spinner shows during fetch; subtle hint on timeout/failure.