### PR TITLE
feat: JSON export — full dump download (#34)

### DIFF
--- a/app/Http/Controllers/Dashboard/ExportController.php
+++ b/app/Http/Controllers/Dashboard/ExportController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Dashboard;
+
+use App\Http\Controllers\Controller;
+use App\Services\ExportService;
+use Illuminate\Http\Response;
+
+class ExportController extends Controller
+{
+    public function __invoke(ExportService $exportService): Response
+    {
+        $payload = $exportService->build();
+        $filename = 'linkshare-export-'.now()->toDateString().'.json';
+
+        return response(
+            json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            200,
+            [
+                'Content-Type' => 'application/json',
+                'Content-Disposition' => "attachment; filename=\"{$filename}\"",
+            ],
+        );
+    }
+}

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Bucket;
+use App\Models\Link;
+use App\Models\Tag;
+
+/**
+ * @phpstan-type ExportBucket array{name: string, color: string, is_inbox: bool}
+ * @phpstan-type ExportTag array{name: string, slug: string, color: string, description: string|null, is_public: bool}
+ * @phpstan-type ExportLink array{url: string, title: string, description: string|null, notes: null, bucket: string, tags: list<string>}
+ * @phpstan-type ExportPayload array{version: int, exported_at: string, includes_notes: bool, buckets: list<ExportBucket>, tags: list<ExportTag>, links: list<ExportLink>}
+ */
+class ExportService
+{
+    /**
+     * Build the full export payload (all active, non-soft-deleted data).
+     *
+     * @return ExportPayload
+     */
+    public function build(): array
+    {
+        $buckets = Bucket::orderBy('is_inbox', 'desc')->orderBy('name')->get();
+        $tags = Tag::orderBy('name')->get();
+        $links = Link::with(['bucket', 'tags'])->orderBy('created_at')->get();
+
+        return [
+            'version' => 1,
+            'exported_at' => now()->toIso8601String(),
+            'includes_notes' => false,
+            'buckets' => $buckets->map(fn (Bucket $bucket) => [
+                'name' => $bucket->name,
+                'color' => $bucket->color,
+                'is_inbox' => (bool) $bucket->is_inbox,
+            ])->values()->all(),
+            'tags' => $tags->map(fn (Tag $tag) => [
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+                'color' => $tag->color,
+                'description' => $tag->description,
+                'is_public' => (bool) $tag->is_public,
+            ])->values()->all(),
+            'links' => $links->map(fn (Link $link) => [
+                'url' => $link->url,
+                'title' => $link->title,
+                'description' => $link->description,
+                'notes' => null,
+                'bucket' => $link->bucket->name,
+                'tags' => $link->tags->pluck('name')->values()->all(),
+            ])->values()->all(),
+        ];
+    }
+}

--- a/database/schema/sqlite-schema.sql
+++ b/database/schema/sqlite-schema.sql
@@ -1,0 +1,161 @@
+CREATE TABLE IF NOT EXISTS "migrations"(
+  "id" integer primary key autoincrement not null,
+  "migration" varchar not null,
+  "batch" integer not null
+);
+CREATE TABLE IF NOT EXISTS "users"(
+  "id" integer primary key autoincrement not null,
+  "name" varchar not null,
+  "email" varchar not null,
+  "email_verified_at" datetime,
+  "password" varchar not null,
+  "remember_token" varchar,
+  "created_at" datetime,
+  "updated_at" datetime,
+  "two_factor_secret" text,
+  "two_factor_recovery_codes" text,
+  "two_factor_confirmed_at" datetime
+);
+CREATE UNIQUE INDEX "users_email_unique" on "users"("email");
+CREATE TABLE IF NOT EXISTS "password_reset_tokens"(
+  "email" varchar not null,
+  "token" varchar not null,
+  "created_at" datetime,
+  primary key("email")
+);
+CREATE TABLE IF NOT EXISTS "sessions"(
+  "id" varchar not null,
+  "user_id" integer,
+  "ip_address" varchar,
+  "user_agent" text,
+  "payload" text not null,
+  "last_activity" integer not null,
+  primary key("id")
+);
+CREATE INDEX "sessions_user_id_index" on "sessions"("user_id");
+CREATE INDEX "sessions_last_activity_index" on "sessions"("last_activity");
+CREATE TABLE IF NOT EXISTS "cache"(
+  "key" varchar not null,
+  "value" text not null,
+  "expiration" integer not null,
+  primary key("key")
+);
+CREATE INDEX "cache_expiration_index" on "cache"("expiration");
+CREATE TABLE IF NOT EXISTS "cache_locks"(
+  "key" varchar not null,
+  "owner" varchar not null,
+  "expiration" integer not null,
+  primary key("key")
+);
+CREATE INDEX "cache_locks_expiration_index" on "cache_locks"("expiration");
+CREATE TABLE IF NOT EXISTS "jobs"(
+  "id" integer primary key autoincrement not null,
+  "queue" varchar not null,
+  "payload" text not null,
+  "attempts" integer not null,
+  "reserved_at" integer,
+  "available_at" integer not null,
+  "created_at" integer not null
+);
+CREATE INDEX "jobs_queue_index" on "jobs"("queue");
+CREATE TABLE IF NOT EXISTS "job_batches"(
+  "id" varchar not null,
+  "name" varchar not null,
+  "total_jobs" integer not null,
+  "pending_jobs" integer not null,
+  "failed_jobs" integer not null,
+  "failed_job_ids" text not null,
+  "options" text,
+  "cancelled_at" integer,
+  "created_at" integer not null,
+  "finished_at" integer,
+  primary key("id")
+);
+CREATE TABLE IF NOT EXISTS "failed_jobs"(
+  "id" integer primary key autoincrement not null,
+  "uuid" varchar not null,
+  "connection" text not null,
+  "queue" text not null,
+  "payload" text not null,
+  "exception" text not null,
+  "failed_at" datetime not null default CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX "failed_jobs_uuid_unique" on "failed_jobs"("uuid");
+CREATE TABLE IF NOT EXISTS "buckets"(
+  "id" integer primary key autoincrement not null,
+  "name" varchar not null,
+  "color" varchar not null default 'gray',
+  "is_inbox" tinyint(1) not null default '0',
+  "created_at" datetime,
+  "updated_at" datetime,
+  "deleted_at" datetime
+);
+CREATE TABLE IF NOT EXISTS "tags"(
+  "id" integer primary key autoincrement not null,
+  "name" varchar not null,
+  "slug" varchar not null,
+  "description" text,
+  "color" varchar not null default 'gray',
+  "is_public" tinyint(1) not null default '0',
+  "created_at" datetime,
+  "updated_at" datetime,
+  "deleted_at" datetime
+);
+CREATE UNIQUE INDEX "tags_slug_unique" on "tags"("slug");
+CREATE TABLE IF NOT EXISTS "link_tag"(
+  "link_id" integer not null,
+  "tag_id" integer not null,
+  foreign key("link_id") references "links"("id") on delete cascade,
+  foreign key("tag_id") references "tags"("id") on delete cascade,
+  primary key("link_id", "tag_id")
+);
+CREATE TABLE IF NOT EXISTS "links"(
+  "id" integer primary key autoincrement not null,
+  "url" varchar not null,
+  "title" varchar not null,
+  "description" text,
+  "notes" text,
+  "bucket_id" integer not null,
+  "created_at" datetime,
+  "updated_at" datetime,
+  "deleted_at" datetime,
+  "favicon_url" varchar,
+  foreign key("bucket_id") references "buckets"("id") on delete restrict
+);
+CREATE TABLE IF NOT EXISTS "media"(
+  "id" integer primary key autoincrement not null,
+  "model_type" varchar not null,
+  "model_id" integer not null,
+  "uuid" varchar,
+  "collection_name" varchar not null,
+  "name" varchar not null,
+  "file_name" varchar not null,
+  "mime_type" varchar,
+  "disk" varchar not null,
+  "conversions_disk" varchar,
+  "size" integer not null,
+  "manipulations" text not null,
+  "custom_properties" text not null,
+  "generated_conversions" text not null,
+  "responsive_images" text not null,
+  "order_column" integer,
+  "created_at" datetime,
+  "updated_at" datetime
+);
+CREATE INDEX "media_model_type_model_id_index" on "media"(
+  "model_type",
+  "model_id"
+);
+CREATE UNIQUE INDEX "media_uuid_unique" on "media"("uuid");
+CREATE INDEX "media_order_column_index" on "media"("order_column");
+
+INSERT INTO migrations VALUES(1,'0001_01_01_000000_create_users_table',1);
+INSERT INTO migrations VALUES(2,'0001_01_01_000001_create_cache_table',1);
+INSERT INTO migrations VALUES(3,'0001_01_01_000002_create_jobs_table',1);
+INSERT INTO migrations VALUES(4,'2025_08_14_170933_add_two_factor_columns_to_users_table',1);
+INSERT INTO migrations VALUES(5,'2026_03_27_235418_create_buckets_table',1);
+INSERT INTO migrations VALUES(6,'2026_03_28_122116_create_tags_table',2);
+INSERT INTO migrations VALUES(7,'2026_03_28_214202_create_link_tag_table',3);
+INSERT INTO migrations VALUES(8,'2026_03_28_214201_create_links_table',3);
+INSERT INTO migrations VALUES(9,'2026_03_29_212754_create_media_table',4);
+INSERT INTO migrations VALUES(10,'2026_03_29_224430_add_favicon_url_to_links_table',5);

--- a/resources/js/pages/dashboard/Import.vue
+++ b/resources/js/pages/dashboard/Import.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { Form, Head, usePage } from '@inertiajs/vue3';
-import { BookmarkPlus, Copy, Upload } from 'lucide-vue-next';
+import { BookmarkPlus, Copy, Download, Upload } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
 import {
     create as importRoute,
     store as storeRoute,
 } from '@/routes/dashboard/import';
+import ExportController from '@/actions/App/Http/Controllers/Dashboard/ExportController';
 import QuickAddController from '@/actions/App/Http/Controllers/Dashboard/QuickAddController';
 import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
@@ -52,16 +53,73 @@ function copyBookmarklet() {
         setTimeout(() => (copied.value = false), 2000);
     });
 }
+
+const exporting = ref(false);
+
+async function downloadExport() {
+    exporting.value = true;
+    try {
+        const csrfToken = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
+        const response = await fetch(ExportController.url(), {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': csrfToken,
+                'X-Inertia': 'false',
+            },
+        });
+
+        if (!response.ok) {
+            return;
+        }
+
+        const blob = await response.blob();
+        const disposition = response.headers.get('Content-Disposition') ?? '';
+        const match = disposition.match(/filename="([^"]+)"/);
+        const filename = match ? match[1] : `linkshare-export-${new Date().toISOString().slice(0, 10)}.json`;
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+    } finally {
+        exporting.value = false;
+    }
+}
 </script>
 
 <template>
-    <Head title="Import" />
+    <Head title="Import & Export" />
 
     <div class="flex flex-col gap-8 p-4">
         <Heading
-            title="Import"
-            description="Importiere Browser-Bookmarks im Netscape HTML Format (Chrome, Firefox, Safari)."
+            title="Import & Export"
+            description="Exportiere oder importiere deine Links, Buckets und Tags."
         />
+
+        <!-- Export section -->
+        <div class="space-y-3">
+            <div>
+                <h2 class="text-sm font-semibold">Exportieren</h2>
+                <p class="mt-0.5 text-sm text-muted-foreground">
+                    Alle aktiven Links, Buckets und Tags als JSON-Datei herunterladen. Einträge im Papierkorb sind nicht enthalten.
+                </p>
+            </div>
+            <Button variant="outline" :disabled="exporting" @click="downloadExport">
+                <Download class="mr-2 size-4" />
+                {{ exporting ? 'Exportiere…' : 'Exportieren' }}
+            </Button>
+        </div>
+
+        <hr class="border-border" />
+
+        <div>
+            <h2 class="text-sm font-semibold">Netscape HTML importieren</h2>
+            <p class="mt-0.5 text-sm text-muted-foreground">
+                Browser-Bookmarks im Netscape HTML Format (Chrome, Firefox, Safari).
+            </p>
+        </div>
 
         <div
             v-if="importResult"

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Dashboard\BucketController;
 use App\Http\Controllers\Dashboard\CheckDuplicateController;
+use App\Http\Controllers\Dashboard\ExportController;
 use App\Http\Controllers\Dashboard\ImportController;
 use App\Http\Controllers\Dashboard\LinkController;
 use App\Http\Controllers\Dashboard\MetaFetchController;
@@ -35,6 +36,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('dashboard/tags/{tag}/force', [DashboardTagController::class, 'forceDelete'])->withTrashed()->name('dashboard.tags.force-delete');
 
     Route::get('dashboard/quick-add', QuickAddController::class)->name('dashboard.quick-add');
+    Route::post('dashboard/export', ExportController::class)->name('dashboard.export');
     Route::get('dashboard/import', [ImportController::class, 'create'])->name('dashboard.import.create');
     Route::post('dashboard/import', [ImportController::class, 'store'])->name('dashboard.import.store');
 

--- a/tests/Feature/ExportServiceTest.php
+++ b/tests/Feature/ExportServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\Bucket;
+use App\Models\Link;
+use App\Models\Tag;
+use App\Services\ExportService;
+
+beforeEach(function () {
+    $this->service = app(ExportService::class);
+    $this->inbox = Bucket::factory()->inbox()->create(['name' => 'Inbox', 'color' => 'gray']);
+});
+
+test('empty app exports valid structure', function () {
+    $payload = $this->service->build();
+
+    expect($payload)
+        ->toHaveKey('version', 1)
+        ->toHaveKey('includes_notes', false)
+        ->toHaveKey('exported_at')
+        ->toHaveKey('buckets')
+        ->toHaveKey('tags')
+        ->toHaveKey('links');
+
+    expect($payload['buckets'])->toHaveCount(1); // inbox
+    expect($payload['tags'])->toBeEmpty();
+    expect($payload['links'])->toBeEmpty();
+});
+
+test('buckets include all required fields', function () {
+    $payload = $this->service->build();
+
+    expect($payload['buckets'][0])
+        ->toHaveKeys(['name', 'color', 'is_inbox'])
+        ->name->toBe('Inbox')
+        ->is_inbox->toBeTrue();
+});
+
+test('tags include all required fields', function () {
+    Tag::factory()->create(['name' => 'design', 'slug' => 'design', 'color' => 'blue', 'description' => 'Design links', 'is_public' => true]);
+
+    $payload = $this->service->build();
+
+    expect($payload['tags'])->toHaveCount(1);
+    expect($payload['tags'][0])
+        ->toHaveKeys(['name', 'slug', 'color', 'description', 'is_public'])
+        ->name->toBe('design')
+        ->slug->toBe('design')
+        ->is_public->toBeTrue()
+        ->description->toBe('Design links');
+});
+
+test('links reference bucket by name not id', function () {
+    Link::factory()->create(['bucket_id' => $this->inbox->id, 'url' => 'https://example.com']);
+
+    $payload = $this->service->build();
+
+    expect($payload['links'][0])
+        ->toHaveKey('bucket', 'Inbox')
+        ->toHaveKey('notes', null);
+});
+
+test('links reference tags by name', function () {
+    $tag = Tag::factory()->create(['name' => 'php']);
+    $link = Link::factory()->create(['bucket_id' => $this->inbox->id]);
+    $link->tags()->attach($tag);
+
+    $payload = $this->service->build();
+
+    expect($payload['links'][0]['tags'])->toBe(['php']);
+});
+
+test('notes is always null', function () {
+    Link::factory()->create(['bucket_id' => $this->inbox->id, 'notes' => 'secret note']);
+
+    $payload = $this->service->build();
+
+    expect($payload['links'][0]['notes'])->toBeNull();
+});
+
+test('soft deleted entries are not exported', function () {
+    $bucket = Bucket::factory()->create();
+    $bucket->delete();
+
+    $tag = Tag::factory()->create();
+    $tag->delete();
+
+    $link = Link::factory()->create(['bucket_id' => $this->inbox->id]);
+    $link->delete();
+
+    $payload = $this->service->build();
+
+    expect($payload['buckets'])->toHaveCount(1); // only inbox
+    expect($payload['tags'])->toBeEmpty();
+    expect($payload['links'])->toBeEmpty();
+});
+
+test('links with no tags export empty tags array', function () {
+    Link::factory()->create(['bucket_id' => $this->inbox->id]);
+
+    $payload = $this->service->build();
+
+    expect($payload['links'][0]['tags'])->toBe([]);
+});

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Models\Bucket;
+use App\Models\Link;
+use App\Models\Tag;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    $this->inbox = Bucket::factory()->inbox()->create();
+});
+
+test('export requires authentication', function () {
+    auth()->logout();
+
+    $this->post(route('dashboard.export'))
+        ->assertRedirect(route('login'));
+});
+
+test('export returns json file download', function () {
+    $response = $this->post(route('dashboard.export'));
+
+    $response->assertOk();
+    $response->assertHeader('Content-Type', 'application/json');
+    expect($response->headers->get('Content-Disposition'))
+        ->toContain('attachment')
+        ->toContain('linkshare-export-')
+        ->toContain('.json');
+});
+
+test('export json contains required top-level fields', function () {
+    $response = $this->post(route('dashboard.export'));
+
+    $data = json_decode($response->getContent(), true);
+
+    expect($data)
+        ->toHaveKey('version', 1)
+        ->toHaveKey('includes_notes', false)
+        ->toHaveKey('exported_at')
+        ->toHaveKey('buckets')
+        ->toHaveKey('tags')
+        ->toHaveKey('links');
+});
+
+test('export includes all active buckets tags and links', function () {
+    $bucket = Bucket::factory()->create(['name' => 'Work']);
+    $tag = Tag::factory()->create(['name' => 'dev']);
+    $link = Link::factory()->create(['bucket_id' => $bucket->id, 'url' => 'https://example.com', 'title' => 'Example']);
+    $link->tags()->attach($tag);
+
+    $data = json_decode($this->post(route('dashboard.export'))->getContent(), true);
+
+    $bucketNames = array_column($data['buckets'], 'name');
+    expect($bucketNames)->toContain('Work');
+
+    $tagNames = array_column($data['tags'], 'name');
+    expect($tagNames)->toContain('dev');
+
+    expect($data['links'])->toHaveCount(1);
+    expect($data['links'][0])->toHaveKey('bucket', 'Work');
+    expect($data['links'][0]['tags'])->toContain('dev');
+});
+
+test('export excludes soft deleted entries', function () {
+    $bucket = Bucket::factory()->create();
+    $bucket->delete();
+
+    $tag = Tag::factory()->create();
+    $tag->delete();
+
+    $link = Link::factory()->create(['bucket_id' => $this->inbox->id]);
+    $link->delete();
+
+    $data = json_decode($this->post(route('dashboard.export'))->getContent(), true);
+
+    expect($data['buckets'])->toHaveCount(1); // only inbox
+    expect($data['tags'])->toBeEmpty();
+    expect($data['links'])->toBeEmpty();
+});
+
+test('export filename contains today date', function () {
+    $response = $this->post(route('dashboard.export'));
+
+    $disposition = $response->headers->get('Content-Disposition');
+    expect($disposition)->toContain('linkshare-export-'.now()->toDateString().'.json');
+});
+
+test('export is valid json', function () {
+    Link::factory()->count(3)->create(['bucket_id' => $this->inbox->id]);
+
+    $content = $this->post(route('dashboard.export'))->getContent();
+
+    expect(json_decode($content, true))->not->toBeNull();
+    expect(json_last_error())->toBe(JSON_ERROR_NONE);
+});


### PR DESCRIPTION
- ExportService builds complete JSON payload (version, exported_at, includes_notes, buckets, tags, links) from active (non-soft-deleted) records; links reference buckets/tags by name
- ExportController POST /dashboard/export returns file download response
- Import page now shows Export section at top with download button (fetch + Blob, no Inertia navigation)
- Fix sqlite-schema.sql migration name mismatch (214201→214202) that caused link_tag collision in tests
- 15 tests: ExportServiceTest (unit-style, in Feature/) and ExportTest (feature)