### PR TITLE
feat: show sub-tags as parent/child in dashboard tiles (#74)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -24,7 +24,7 @@ class DashboardController extends Controller
             $tagDelta = Tag::where('created_at', '>=', $sevenDaysAgo)->count();
             $publicTagDelta = Tag::where('is_public', true)->where('updated_at', '>=', $sevenDaysAgo)->count();
 
-            $recentLinks = Link::with('bucket', 'tags')
+            $recentLinks = Link::with(['bucket', 'tags.parent'])
                 ->latest()
                 ->limit(10)
                 ->get()
@@ -34,11 +34,18 @@ class DashboardController extends Controller
                     'title' => $link->title,
                     'favicon_url' => $link->getFirstMediaUrl('favicon') ?: null,
                     'bucket' => $link->bucket ? ['id' => $link->bucket->id, 'name' => $link->bucket->name, 'color' => $link->bucket->color] : null,
-                    'tags' => $link->tags->map(fn (Tag $tag) => ['id' => $tag->id, 'name' => $tag->name, 'color' => $tag->color])->values()->all(),
+                    'tags' => $link->tags->map(fn (Tag $tag) => [
+                        'id' => $tag->id,
+                        'name' => $tag->name,
+                        'color' => $tag->color,
+                        'parent_id' => $tag->parent_id,
+                        'parent' => $tag->parent ? ['id' => $tag->parent->id, 'name' => $tag->parent->name, 'color' => $tag->parent->color] : null,
+                    ])->values()->all(),
                 ])
                 ->all();
 
-            $tags = Tag::withCount('links')
+            $tags = Tag::with(['parent:id,name,color', 'children' => fn ($q) => $q->withCount('links')])
+                ->withCount('links')
                 ->get()
                 ->map(fn (Tag $tag) => [
                     'id' => $tag->id,
@@ -46,7 +53,11 @@ class DashboardController extends Controller
                     'slug' => $tag->slug,
                     'color' => $tag->color,
                     'is_public' => $tag->is_public,
+                    'parent_id' => $tag->parent_id,
+                    'parent' => $tag->parent ? ['id' => $tag->parent->id, 'name' => $tag->parent->name, 'color' => $tag->parent->color] : null,
                     'links_count' => $tag->links_count,
+                    'total_links_count' => $tag->links_count + $tag->children->sum('links_count'),
+                    'children_count' => $tag->children->count(),
                     'updated_at' => $tag->updated_at?->toISOString(),
                 ])
                 ->all();

--- a/resources/js/components/dashboard/AllTagsTile.vue
+++ b/resources/js/components/dashboard/AllTagsTile.vue
@@ -29,6 +29,10 @@ function openTagLinks(tag: DashboardTag): void {
         LinkController.index.url({ query: { tag_id: String(tag.id) } }),
     );
 }
+
+function displayName(tag: DashboardTag): string {
+    return tag.parent ? `${tag.parent.name} / ${tag.name}` : tag.name;
+}
 </script>
 
 <template>
@@ -79,9 +83,12 @@ function openTagLinks(tag: DashboardTag): void {
                                     : ''
                             "
                         >
-                            {{ tag.name }}
+                            {{ displayName(tag) }}
                         </span>
-                        <span class="shrink-0 text-xs text-muted-foreground">
+                        <span
+                            class="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground"
+                            :aria-label="`${tag.links_count} Links`"
+                        >
                             {{ tag.links_count }}
                         </span>
                         <Globe

--- a/resources/js/components/dashboard/PublicTagsTile.vue
+++ b/resources/js/components/dashboard/PublicTagsTile.vue
@@ -14,7 +14,9 @@ type Props = {
 };
 
 const props = defineProps<Props>();
-const publicTags = computed(() => props.tags.filter((t) => t.is_public));
+const publicTags = computed(() =>
+    props.tags.filter((t) => t.is_public && !t.parent_id),
+);
 const { t } = useI18n();
 
 const {
@@ -87,8 +89,18 @@ function copyTagUrl(tag: DashboardTag): void {
                     >
                         {{ tag.name }}
                     </a>
-                    <span class="shrink-0 text-xs text-muted-foreground">
-                        {{ tag.links_count }}
+                    <span
+                        class="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground"
+                        :aria-label="`${tag.total_links_count} Links`"
+                    >
+                        {{ tag.total_links_count }}
+                    </span>
+                    <span
+                        v-if="tag.children_count > 0"
+                        class="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground"
+                        :aria-label="`${tag.children_count} Sub-Tags`"
+                    >
+                        {{ tag.children_count }}
                     </span>
                     <a
                         :href="TagsRoute.show.url(tag.slug ?? '')"

--- a/resources/js/composables/useTagSortAndFilter.ts
+++ b/resources/js/composables/useTagSortAndFilter.ts
@@ -1,6 +1,10 @@
-import { computed, ref  } from 'vue';
-import type {ComputedRef} from 'vue';
+import { computed, ref } from 'vue';
+import type { ComputedRef } from 'vue';
 import type { DashboardTag, SortKey } from '@/types/dashboard';
+
+function displayName(tag: DashboardTag): string {
+    return tag.parent ? `${tag.parent.name} / ${tag.name}` : tag.name;
+}
 
 export function useTagSortAndFilter(tags: ComputedRef<DashboardTag[]>) {
     const sortKey = ref<SortKey>('updated_at');
@@ -15,12 +19,14 @@ export function useTagSortAndFilter(tags: ComputedRef<DashboardTag[]>) {
 
         if (search.trim()) {
             const q = search.trim().toLowerCase();
-            result = result.filter((t) => t.name.toLowerCase().includes(q));
+            result = result.filter((t) =>
+                displayName(t).toLowerCase().includes(q),
+            );
         }
 
         return [...result].sort((a, b) => {
             if (sort === 'name') {
-                return a.name.localeCompare(b.name);
+                return displayName(a).localeCompare(displayName(b));
             }
 
             if (sort === 'links_count') {
@@ -34,6 +40,7 @@ export function useTagSortAndFilter(tags: ComputedRef<DashboardTag[]>) {
             );
         });
     }
+
     const sorted = computed(() =>
         sortedAndFiltered(tags.value, sortKey.value, search.value),
     );

--- a/resources/js/types/dashboard.ts
+++ b/resources/js/types/dashboard.ts
@@ -72,6 +72,8 @@ export const TAG_SEARCH_THRESHOLD = 8;
 
 export type DashboardTag = Tag & {
     links_count: number;
+    total_links_count: number;
+    children_count: number;
     updated_at: string;
 };
 


### PR DESCRIPTION
- DashboardController: load tags.parent for recent_links; load parent, children with links_count for tags; expose parent_id, parent, total_links_count, children_count per tag
- DashboardTag type: add total_links_count and children_count fields
- useTagSortAndFilter: search and name-sort use full display name (parent / child) so searching "vue" finds "vue / pinia"
- AllTagsTile: render displayName() for child tags; link count as pill with aria-label
- PublicTagsTile: filter to root-only tags; show total_links_count (aggregated incl. sub-tags) as pill; show children_count pill when > 0
- RecentLinksTile: no change needed — PillTag renders parent/child automatically via newly loaded parent relation